### PR TITLE
feat: relative input position

### DIFF
--- a/crates/common/src/event/input.rs
+++ b/crates/common/src/event/input.rs
@@ -11,8 +11,10 @@ pub enum InputEvent {
 #[derive(Debug, Encode, Decode, Clone)]
 pub struct CursorInput {
     pub event: CursorEvent,
-    pub x: i16,
-    pub y: i16,
+    /// Position relative to overlay surface
+    pub client: InputPosition,
+    /// Position relative to window
+    pub window: InputPosition,
 }
 
 #[derive(Debug, Encode, Decode, Clone)]
@@ -55,4 +57,11 @@ pub enum ScrollAxis {
 pub enum InputState {
     Pressed,
     Released,
+}
+
+
+#[derive(Debug, Encode, Decode, Clone, Copy)]
+pub struct InputPosition {
+    pub x: f32,
+    pub y: f32,
 }

--- a/crates/common/src/event/input.rs
+++ b/crates/common/src/event/input.rs
@@ -59,7 +59,6 @@ pub enum InputState {
     Released,
 }
 
-
 #[derive(Debug, Encode, Decode, Clone, Copy)]
 pub struct InputPosition {
     pub x: f32,

--- a/crates/node/src/conv.rs
+++ b/crates/node/src/conv.rs
@@ -109,11 +109,17 @@ fn serialize_cursor_input<'a>(
 ) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
-    let x = cx.number(input.x);
-    obj.set(cx, "x", x)?;
+    let client_x = cx.number(input.client.x);
+    obj.set(cx, "clientX", client_x)?;
 
-    let y = cx.number(input.y);
-    obj.set(cx, "y", y)?;
+    let client_y = cx.number(input.client.y);
+    obj.set(cx, "clientY", client_y)?;
+
+    let window_x = cx.number(input.client.x);
+    obj.set(cx, "windowX", window_x)?;
+
+    let window_y = cx.number(input.client.y);
+    obj.set(cx, "windowY", window_y)?;
 
     match input.event {
         CursorEvent::Enter => {

--- a/crates/overlay/src/app.rs
+++ b/crates/overlay/src/app.rs
@@ -40,15 +40,17 @@ async fn run(mut server: IpcServerConn) -> anyhow::Result<()> {
     fn handle_window_event(hwnd: u32, req: WindowRequest) -> anyhow::Result<bool> {
         let res = Backends::with_backend(HWND(hwnd as _), |backend| match req {
             WindowRequest::SetPosition(position) => {
-                backend.layout.position = position;
+                backend.layout.set_position(position.x, position.y);
             }
 
             WindowRequest::SetAnchor(anchor) => {
-                backend.layout.anchor = anchor;
+                backend.layout.set_anchor(anchor.x, anchor.y);
             }
 
             WindowRequest::SetMargin(margin) => {
-                backend.layout.margin = margin;
+                backend
+                    .layout
+                    .set_margin(margin.top, margin.right, margin.bottom, margin.left);
             }
 
             WindowRequest::ListenInput(cmd) => {

--- a/crates/overlay/src/hook/dx/dx9.rs
+++ b/crates/overlay/src/hook/dx/dx9.rs
@@ -83,7 +83,7 @@ fn draw_overlay(hwnd: HWND, device: &IDirect3DDevice9) {
         let size = surface.size();
         let position = backend
             .layout
-            .calc_position((size.0 as _, size.1 as _), screen);
+            .get_or_calc((size.0 as _, size.1 as _), screen);
 
         let interop = &mut backend.interop;
         match reader.with_mapped(

--- a/crates/overlay/src/hook/dx/dxgi.rs
+++ b/crates/overlay/src/hook/dx/dxgi.rs
@@ -89,7 +89,7 @@ fn draw_overlay(backend: &mut WindowBackend, swapchain: &IDXGISwapChain1) {
             let size = surface.size();
             let position = backend
                 .layout
-                .calc_position((size.0 as _, size.1 as _), screen);
+                .get_or_calc((size.0 as _, size.1 as _), screen);
             trace!("using dx12 renderer");
             let backbuffer_index = unsafe { swapchain.GetCurrentBackBufferIndex() };
             let _res =
@@ -183,7 +183,7 @@ fn draw_overlay(backend: &mut WindowBackend, swapchain: &IDXGISwapChain1) {
         let size = surface.size();
         let position = backend
             .layout
-            .calc_position((size.0 as _, size.1 as _), screen);
+            .get_or_calc((size.0 as _, size.1 as _), screen);
         {
             let back_buffer = unsafe { swapchain.GetBuffer::<ID3D11Texture2D>(0) }
                 .expect("failed to get dx11 backbuffer");

--- a/crates/overlay/src/hook/opengl.rs
+++ b/crates/overlay/src/hook/opengl.rs
@@ -165,7 +165,7 @@ fn draw_overlay(hdc: HDC) {
                 let size = surface.size();
                 let position = backend
                     .layout
-                    .calc_position((size.0 as _, size.1 as _), screen);
+                    .get_or_calc((size.0 as _, size.1 as _), screen);
                 let _res = renderer.draw(position, size, screen);
                 trace!("opengl render: {:?}", _res);
             })

--- a/crates/overlay/src/layout.rs
+++ b/crates/overlay/src/layout.rs
@@ -1,48 +1,80 @@
-use asdf_overlay_common::{
-    request::{SetAnchor, SetMargin, SetPosition},
-    size::PercentLength,
-};
+use asdf_overlay_common::size::PercentLength;
 
 #[derive(Clone)]
 pub struct OverlayLayout {
-    pub position: SetPosition,
-    pub anchor: SetAnchor,
-    pub margin: SetMargin,
+    position: (PercentLength, PercentLength),
+    anchor: (PercentLength, PercentLength),
+    margin: (PercentLength, PercentLength, PercentLength, PercentLength),
+    cache: Option<LayoutCache>,
 }
 
 impl OverlayLayout {
     pub const fn new() -> Self {
         Self {
-            position: SetPosition {
-                x: PercentLength::ZERO,
-                y: PercentLength::ZERO,
-            },
-            anchor: SetAnchor {
-                x: PercentLength::ZERO,
-                y: PercentLength::ZERO,
-            },
-            margin: SetMargin {
-                top: PercentLength::ZERO,
-                right: PercentLength::ZERO,
-                bottom: PercentLength::ZERO,
-                left: PercentLength::ZERO,
-            },
+            position: (PercentLength::ZERO, PercentLength::ZERO),
+            anchor: (PercentLength::ZERO, PercentLength::ZERO),
+            margin: (
+                PercentLength::ZERO,
+                PercentLength::ZERO,
+                PercentLength::ZERO,
+                PercentLength::ZERO,
+            ),
+            cache: None,
         }
     }
 
-    pub fn calc_position(&self, size: (f32, f32), screen: (u32, u32)) -> (f32, f32) {
+    pub fn set_position(&mut self, x: PercentLength, y: PercentLength) {
+        self.cache.take();
+        self.position = (x, y);
+    }
+
+    pub fn set_anchor(&mut self, x: PercentLength, y: PercentLength) {
+        self.cache.take();
+        self.anchor = (x, y);
+    }
+
+    pub fn set_margin(
+        &mut self,
+        top: PercentLength,
+        right: PercentLength,
+        bottom: PercentLength,
+        left: PercentLength,
+    ) {
+        self.cache.take();
+        self.margin = (top, right, bottom, left);
+    }
+
+    pub fn get_or_calc(&mut self, size: (u32, u32), screen: (u32, u32)) -> (f32, f32) {
+        if let Some(ref cache) = self.cache {
+            if let Some(position) = cache.resolve(size, screen) {
+                return position;
+            }
+        }
+
+        let final_position = self.calc_position(size, screen);
+        self.cache = Some(LayoutCache {
+            size,
+            screen,
+            final_position,
+        });
+        final_position
+    }
+
+    fn calc_position(&self, size: (u32, u32), screen: (u32, u32)) -> (f32, f32) {
+        let size = (size.0 as f32, size.1 as f32);
         let screen = (screen.0 as f32, screen.1 as f32);
+        let (x, y) = self.position;
+        let (anchor_x, anchor_y) = self.anchor;
+        let (margin_top, margin_right, margin_bottom, margin_left) = self.margin;
 
-        let margin_left = self.margin.left.resolve(screen.0);
-        let margin_top = self.margin.top.resolve(screen.1);
+        let margin_left = margin_left.resolve(screen.0);
+        let margin_top = margin_top.resolve(screen.1);
 
-        let outer_width = margin_left + size.0 + self.margin.right.resolve(screen.0);
-        let outer_height = margin_top + size.1 + self.margin.bottom.resolve(screen.1);
+        let outer_width = margin_left + size.0 + margin_right.resolve(screen.0);
+        let outer_height = margin_top + size.1 + margin_bottom.resolve(screen.1);
 
-        let x =
-            self.position.x.resolve(screen.0) - self.anchor.x.resolve(outer_width) + margin_left;
-        let y =
-            self.position.y.resolve(screen.1) - self.anchor.y.resolve(outer_height) + margin_top;
+        let x = x.resolve(screen.0) - anchor_x.resolve(outer_width) + margin_left;
+        let y = y.resolve(screen.1) - anchor_y.resolve(outer_height) + margin_top;
 
         (x, y)
     }
@@ -51,5 +83,22 @@ impl OverlayLayout {
 impl Default for OverlayLayout {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Clone)]
+struct LayoutCache {
+    pub size: (u32, u32),
+    pub screen: (u32, u32),
+    pub final_position: (f32, f32),
+}
+
+impl LayoutCache {
+    pub fn resolve(&self, size: (u32, u32), screen: (u32, u32)) -> Option<(f32, f32)> {
+        if size == self.size && self.screen == screen {
+            Some(self.final_position)
+        } else {
+            None
+        }
     }
 }

--- a/examples/node/ingame-browser/main/index.ts
+++ b/examples/node/ingame-browser/main/index.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow } from 'electron';
-import { defaultDllDir, Overlay } from 'asdf-overlay-node';
+import { defaultDllDir, Overlay, percent } from 'asdf-overlay-node';
 import { InputState } from 'asdf-overlay-node/input';
 import find from 'find-process';
 import { toCursor, toKeyboardInputEvent, toMouseEvent } from './input';
@@ -47,6 +47,10 @@ async function createOverlayWindow(pid: number) {
   });
 
   const hwnd = await new Promise<number>((resolve) => overlay.event.once('added', resolve));
+
+  // centre layout
+  overlay.setPosition(hwnd, percent(0.5), percent(0.5));
+  overlay.setAnchor(hwnd, percent(0.5), percent(0.5));
 
   // always listen keyboard events
   await overlay.listenInput(hwnd, false, true);

--- a/examples/node/ingame-browser/main/input.ts
+++ b/examples/node/ingame-browser/main/input.ts
@@ -15,22 +15,28 @@ export function toMouseEvent(
     case 'Enter':
       return {
         type: 'mouseEnter',
-        x: input.x,
-        y: input.y
+        x: input.clientX,
+        y: input.clientY,
+        globalX: input.windowX,
+        globalY: input.windowY,
       };
 
     case 'Leave':
       return {
         type: 'mouseLeave',
-        x: input.x,
-        y: input.y
+        x: input.clientX,
+        y: input.clientY,
+        globalX: input.windowX,
+        globalY: input.windowY,
       };
 
     case 'Move':
       return {
         type: 'mouseMove',
-        x: input.x,
-        y: input.y
+        x: input.clientX,
+        y: input.clientY,
+        globalX: input.windowX,
+        globalY: input.windowY,
       };
 
     case 'Scroll':
@@ -38,15 +44,19 @@ export function toMouseEvent(
         return {
           type: 'mouseWheel',
           deltaY: input.delta,
-          x: input.x,
-          y: input.y
+          x: input.clientX,
+          y: input.clientY,
+          globalX: input.windowX,
+          globalY: input.windowY,
         };
       } else {
         return {
           type: 'mouseWheel',
           deltaX: input.delta,
-          x: input.x,
-          y: input.y
+          x: input.clientX,
+          y: input.clientY,
+          globalX: input.windowX,
+          globalY: input.windowY,
         };
       }
 
@@ -73,8 +83,10 @@ export function toMouseEvent(
         type: input.state === 'Pressed' ? 'mouseDown' : 'mouseUp',
         button,
         clickCount: 1,
-        x: input.x,
-        y: input.y
+        x: input.clientX,
+        y: input.clientY,
+        globalX: input.windowX,
+        globalY: input.windowY,
       };
     }
   }
@@ -107,54 +119,54 @@ export function toKeyboardInputEvent(
 // https://www.electronjs.org/docs/latest/api/web-contents
 // https://developer.mozilla.org/ko/docs/Web/CSS/cursor
 export function toCursor(cursor: string): Cursor | undefined {
-    switch (cursor) {
-        case 'pointer': return Cursor.Default;
-        case 'crosshair': return Cursor.Crosshair;
-        case 'hand': return Cursor.Pointer;
-        case 'text': return Cursor.Text;
-        case 'wait': return Cursor.Wait;
-        case 'help': return Cursor.Help;
-        case 'e-resize':
-        case 'w-resize':
-        case 'ew-resize': return Cursor.EastWestResize;
-        case 'n-resize':
-        case 's-resize':
-        case 'ns-resize': return Cursor.NorthSouthResize;
-        case 'ne-resize':
-        case 'sw-resize':
-        case 'nesw-resize': return Cursor.NorthEastSouthWestResize;
-        case 'nw-resize':
-        case 'se-resize':
-        case 'nwse-resize': return Cursor.NorthWestSouthEastResize;
-        case 'col-resize': return Cursor.ColResize;
-        case 'row-resize': return Cursor.RowResize;
-        case 'm-panning': return Cursor.PanMiddle;
-        case 'm-panning-vertical': return Cursor.PanMiddleVertical;
-        case 'm-panning-horizontal': return Cursor.PanMiddleHorizontal;
-        case 'e-panning': return Cursor.PanEast;
-        case 'n-panning': return Cursor.PanNorth;
-        case 'ne-panning': return Cursor.PanNorthEast;
-        case 'nw-panning': return Cursor.PanNorthWest;
-        case 's-panning': return Cursor.PanSouth;
-        case 'se-panning': return Cursor.PanSouthEast;
-        case 'sw-panning': return Cursor.PanSouthWest;
-        case 'w-panning': return Cursor.PanWest;
-        case 'move': return Cursor.Move;
-        case 'vertical-text': return Cursor.VerticalText;
-        case 'cell': return Cursor.Cell;
-        case 'alias': return Cursor.Alias;
-        case 'progress': return Cursor.Progress;
-        case 'nodrop':
-        case 'not-allowed': return Cursor.NotAllowed;
-        case 'copy': return Cursor.Copy;
-        case 'none': return;
-        case 'zoom-in': return Cursor.ZoomIn;
-        case 'zoom-out': return Cursor.ZoomOut;
-        case 'grab': return Cursor.Grab;
-        case 'grabbing': return Cursor.Grabbing;
+  switch (cursor) {
+    case 'pointer': return Cursor.Default;
+    case 'crosshair': return Cursor.Crosshair;
+    case 'hand': return Cursor.Pointer;
+    case 'text': return Cursor.Text;
+    case 'wait': return Cursor.Wait;
+    case 'help': return Cursor.Help;
+    case 'e-resize':
+    case 'w-resize':
+    case 'ew-resize': return Cursor.EastWestResize;
+    case 'n-resize':
+    case 's-resize':
+    case 'ns-resize': return Cursor.NorthSouthResize;
+    case 'ne-resize':
+    case 'sw-resize':
+    case 'nesw-resize': return Cursor.NorthEastSouthWestResize;
+    case 'nw-resize':
+    case 'se-resize':
+    case 'nwse-resize': return Cursor.NorthWestSouthEastResize;
+    case 'col-resize': return Cursor.ColResize;
+    case 'row-resize': return Cursor.RowResize;
+    case 'm-panning': return Cursor.PanMiddle;
+    case 'm-panning-vertical': return Cursor.PanMiddleVertical;
+    case 'm-panning-horizontal': return Cursor.PanMiddleHorizontal;
+    case 'e-panning': return Cursor.PanEast;
+    case 'n-panning': return Cursor.PanNorth;
+    case 'ne-panning': return Cursor.PanNorthEast;
+    case 'nw-panning': return Cursor.PanNorthWest;
+    case 's-panning': return Cursor.PanSouth;
+    case 'se-panning': return Cursor.PanSouthEast;
+    case 'sw-panning': return Cursor.PanSouthWest;
+    case 'w-panning': return Cursor.PanWest;
+    case 'move': return Cursor.Move;
+    case 'vertical-text': return Cursor.VerticalText;
+    case 'cell': return Cursor.Cell;
+    case 'alias': return Cursor.Alias;
+    case 'progress': return Cursor.Progress;
+    case 'nodrop':
+    case 'not-allowed': return Cursor.NotAllowed;
+    case 'copy': return Cursor.Copy;
+    case 'none': return;
+    case 'zoom-in': return Cursor.ZoomIn;
+    case 'zoom-out': return Cursor.ZoomOut;
+    case 'grab': return Cursor.Grab;
+    case 'grabbing': return Cursor.Grabbing;
 
-        default: return Cursor.Default;
-    }
+    default: return Cursor.Default;
+  }
 }
 
 // As per https://www.electronjs.org/docs/latest/api/accelerator

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,8 +1,10 @@
 import { Key } from './index.js';
 
 export type CursorInput = {
-  x: number,
-  y: number,
+  clientX: number,
+  clientY: number,
+  windowX: number,
+  windowY: number,
 } & ({
   kind: 'Enter'
 } | {


### PR DESCRIPTION
* add `client`(relative to overlay surface position) cursor position to `CursorInput`. fix #53.
* add `window`(relative to window's client position) cursor position to `CursorInput`
* update typescript type definition
* update node example
* fix wheel click scroll via added cursor positions