### PR TITLE
feat: strictly check if GL_EXT_memory_object_win32 is fully supported

### DIFF
--- a/crates/overlay/src/renderer/opengl.rs
+++ b/crates/overlay/src/renderer/opengl.rs
@@ -335,6 +335,9 @@ impl MemoryObjectTexture {
                 gl::HANDLE_TYPE_D3D11_IMAGE_KMT_EXT,
                 handle,
             );
+            if gl::GetError() != gl::NO_ERROR {
+                bail!("ImportMemoryWin32HandleEXT failed");
+            }
 
             let mut texture = 0;
             gl::GenTextures(1, &mut texture);


### PR DESCRIPTION
* Some drivers fake report it supported and emit error
ref: https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/1143
