### PR TITLE
feat: gpu id on window added event

### DIFF
--- a/crates/dll/src/lib.rs
+++ b/crates/dll/src/lib.rs
@@ -114,12 +114,15 @@ async fn run(server: NamedPipeServer) -> anyhow::Result<()> {
         debug!("sending initial data");
         // send existing windows
         for backend in Backends::iter() {
-            let size = backend.render.lock().window_size;
+            let render = backend.render.lock();
+            let gpu_id = render.interop.gpu_id();
+            let size = render.window_size;
             _ = emitter.emit(ClientEvent::Window {
                 id: *backend.key() as _,
                 event: WindowEvent::Added {
                     width: size.0,
                     height: size.1,
+                    gpu_id,
                 },
             });
         }

--- a/crates/event/src/lib.rs
+++ b/crates/event/src/lib.rs
@@ -12,7 +12,7 @@ pub enum ClientEvent {
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 pub enum WindowEvent {
     // Window is hooked and added
-    Added { width: u32, height: u32 },
+    Added { width: u32, height: u32, gpu_id: GpuLuid },
 
     // Window is resized
     Resized { width: u32, height: u32 },
@@ -25,4 +25,11 @@ pub enum WindowEvent {
 
     // Window destroyed
     Destroyed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+pub struct GpuLuid {
+    pub low: u32,
+    pub high: i32,
 }

--- a/crates/event/src/lib.rs
+++ b/crates/event/src/lib.rs
@@ -12,10 +12,17 @@ pub enum ClientEvent {
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 pub enum WindowEvent {
     // Window is hooked and added
-    Added { width: u32, height: u32, gpu_id: GpuLuid },
+    Added {
+        width: u32,
+        height: u32,
+        gpu_id: GpuLuid,
+    },
 
     // Window is resized
-    Resized { width: u32, height: u32 },
+    Resized {
+        width: u32,
+        height: u32,
+    },
 
     // Captured window input
     Input(InputEvent),

--- a/crates/node/src/conv.rs
+++ b/crates/node/src/conv.rs
@@ -1,10 +1,11 @@
 use asdf_overlay_client::{
     common::size::PercentLength,
     event::{
+        ClientEvent, GpuLuid, WindowEvent,
         input::{
             CursorAction, CursorEvent, CursorInput, CursorInputState, Ime, InputEvent, Key,
             KeyInputState, KeyboardInput, ScrollAxis,
-        }, ClientEvent, GpuLuid, WindowEvent
+        },
     },
     ty::{CopyRect, Rect},
 };
@@ -27,7 +28,11 @@ pub fn emit_event<'a>(
 
     match event {
         ClientEvent::Window { id, event } => match event {
-            WindowEvent::Added { width, height, gpu_id } => {
+            WindowEvent::Added {
+                width,
+                height,
+                gpu_id,
+            } => {
                 builder
                     .arg(cx.string("added"))
                     .arg(cx.number(id))
@@ -70,77 +75,71 @@ pub fn emit_event<'a>(
     builder.exec(cx)
 }
 
-fn serialize_keyboard_input<'a>(
-    cx: &mut Cx<'a>,
-    input: KeyboardInput,
-) -> JsResult<'a, JsObject> {
+fn serialize_keyboard_input<'a>(cx: &mut Cx<'a>, input: KeyboardInput) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
     match input {
         KeyboardInput::Key { key, state } => {
             let kind = cx.string("Key");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
 
             let key = serialize_key(cx, key)?;
-            obj.set(cx, "key", key)?;
+            obj.prop(cx, "key").set(key)?;
 
             let state = serialize_key_input_state(cx, state);
-            obj.set(cx, "state", state)?;
+            obj.prop(cx, "state").set(state)?;
         }
         KeyboardInput::Char(ch) => {
             let kind = cx.string("Char");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
 
             let mut buf = [0_u8; 4];
             let ch = cx.string(ch.encode_utf8(&mut buf));
-            obj.set(cx, "ch", ch)?;
+            obj.prop(cx, "ch").set(ch)?;
         }
         KeyboardInput::Ime(ime) => {
             let kind = cx.string("Ime");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
 
             let ime = serialize_ime(cx, ime)?;
-            obj.set(cx, "ime", ime)?;
+            obj.prop(cx, "ime").set(ime)?;
         }
     }
 
     Ok(obj)
 }
 
-fn serialize_cursor_input<'a>(
-    cx: &mut Cx<'a>,
-    input: CursorInput,
-) -> JsResult<'a, JsObject> {
+fn serialize_cursor_input<'a>(cx: &mut Cx<'a>, input: CursorInput) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
     let client_x = cx.number(input.client.x);
-    obj.set(cx, "clientX", client_x)?;
+    obj.prop(cx, "clientX").set(client_x)?;
 
     let client_y = cx.number(input.client.y);
-    obj.set(cx, "clientY", client_y)?;
+    obj.prop(cx, "clientY").set(client_y)?;
 
     let window_x = cx.number(input.client.x);
-    obj.set(cx, "windowX", window_x)?;
+    obj.prop(cx, "windowX").set(window_x)?;
 
     let window_y = cx.number(input.client.y);
-    obj.set(cx, "windowY", window_y)?;
+    obj.prop(cx, "windowY").set(window_y)?;
 
     match input.event {
         CursorEvent::Enter => {
             let kind = cx.string("Enter");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
         }
         CursorEvent::Leave => {
             let kind = cx.string("Leave");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
         }
         CursorEvent::Action { state, action } => {
             let kind = cx.string("Action");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
 
             let (state, double_click) = serialize_cursor_input_state(cx, state);
-            obj.set(cx, "state", state)?;
-            obj.set(cx, "doubleClick", double_click)?;
+            obj.prop(cx, "state").set(state)?;
+            obj.prop(cx, "doubleClick").set(double_click)?;
 
             let action = match action {
                 CursorAction::Left => cx.string("Left"),
@@ -149,34 +148,31 @@ fn serialize_cursor_input<'a>(
                 CursorAction::Back => cx.string("Back"),
                 CursorAction::Forward => cx.string("Forward"),
             };
-            obj.set(cx, "action", action)?;
+            obj.prop(cx, "action").set(action)?;
         }
         CursorEvent::Move => {
             let kind = cx.string("Move");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
         }
         CursorEvent::Scroll { axis, delta } => {
             let kind = cx.string("Scroll");
-            obj.set(cx, "kind", kind)?;
+            obj.prop(cx, "kind").set(kind)?;
 
             let axis = match axis {
                 ScrollAxis::X => cx.string("X"),
                 ScrollAxis::Y => cx.string("Y"),
             };
-            obj.set(cx, "axis", axis)?;
+            obj.prop(cx, "axis").set(axis)?;
 
             let delta = cx.number(delta);
-            obj.set(cx, "delta", delta)?;
+            obj.prop(cx, "delta").set(delta)?;
         }
     }
 
     Ok(obj)
 }
 
-fn serialize_gpu_luid<'a>(
-    cx: &mut Cx<'a>,
-    id: GpuLuid,
-) -> JsResult<'a, JsObject> {
+fn serialize_gpu_luid<'a>(cx: &mut Cx<'a>, id: GpuLuid) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
     let low = cx.number(id.low);
@@ -188,10 +184,7 @@ fn serialize_gpu_luid<'a>(
     Ok(obj)
 }
 
-fn serialize_key_input_state<'a>(
-    cx: &mut Cx<'a>,
-    state: KeyInputState,
-) -> Handle<'a, JsString> {
+fn serialize_key_input_state<'a>(cx: &mut Cx<'a>, state: KeyInputState) -> Handle<'a, JsString> {
     match state {
         KeyInputState::Pressed => cx.string("Pressed"),
         KeyInputState::Released => cx.string("Released"),
@@ -214,10 +207,10 @@ fn serialize_key<'a>(cx: &mut Cx<'a>, key: Key) -> JsResult<'a, JsObject> {
     let obj = cx.empty_object();
 
     let code = cx.number(key.code.get());
-    obj.set(cx, "code", code)?;
+    obj.prop(cx, "code").set(code)?;
 
     let extended = cx.boolean(key.extended);
-    obj.set(cx, "extended", extended)?;
+    obj.prop(cx, "extended").set(extended)?;
 
     Ok(obj)
 }
@@ -228,43 +221,43 @@ fn serialize_ime<'a>(cx: &mut Cx<'a>, ime: Ime) -> JsResult<'a, JsObject> {
     let kind = match ime {
         Ime::Enabled { lang, conversion } => {
             let lang = cx.string(lang);
-            obj.set(cx, "lang", lang)?;
+            obj.prop(cx, "lang").set(lang)?;
 
             let conversion = cx.number(conversion.bits());
-            obj.set(cx, "conversion", conversion)?;
+            obj.prop(cx, "conversion").set(conversion)?;
 
             cx.string("Enabled")
         }
         Ime::Changed(lang) => {
             let lang = cx.string(lang);
-            obj.set(cx, "lang", lang)?;
+            obj.prop(cx, "lang").set(lang)?;
 
             cx.string("Changed")
         }
         Ime::ConversionChanged(conversion) => {
             let conversion = cx.number(conversion.bits());
-            obj.set(cx, "conversion", conversion)?;
+            obj.prop(cx, "conversion").set(conversion)?;
 
             cx.string("ConversionChanged")
         }
         Ime::Compose { text, caret } => {
             let text = cx.string(text);
-            obj.set(cx, "text", text)?;
+            obj.prop(cx, "text").set(text)?;
 
             let caret = cx.number(caret as f64);
-            obj.set(cx, "caret", caret)?;
+            obj.prop(cx, "caret").set(caret)?;
 
             cx.string("Compose")
         }
         Ime::Commit(text) => {
             let text = cx.string(text);
-            obj.set(cx, "text", text)?;
+            obj.prop(cx, "text").set(text)?;
 
             cx.string("Commit")
         }
         Ime::Disabled => cx.string("Disabled"),
     };
-    obj.set(cx, "kind", kind)?;
+    obj.prop(cx, "kind").set(kind)?;
 
     Ok(obj)
 }

--- a/crates/overlay/src/backend.rs
+++ b/crates/overlay/src/backend.rs
@@ -87,6 +87,7 @@ impl Backends {
                     event: WindowEvent::Added {
                         width: window_size.0,
                         height: window_size.1,
+                        gpu_id: interop.gpu_id(),
                     },
                 });
 

--- a/crates/overlay/src/interop.rs
+++ b/crates/overlay/src/interop.rs
@@ -43,7 +43,8 @@ impl DxInterop {
                 Some(&mut device),
                 None,
                 Some(&mut cx),
-            ).context("D3D11CreateDevice failed")?;
+            )
+            .context("D3D11CreateDevice failed")?;
             let device = device.unwrap();
             let cx = cx.unwrap();
 

--- a/crates/overlay/src/interop.rs
+++ b/crates/overlay/src/interop.rs
@@ -1,19 +1,25 @@
 use core::ptr;
 
+use anyhow::Context;
+use asdf_overlay_event::GpuLuid;
 use sync_wrapper::SyncWrapper;
-use windows::Win32::{
-    Foundation::HMODULE,
-    Graphics::{
-        Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_DRIVER_TYPE_UNKNOWN},
-        Direct3D11::{
-            D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION, D3D11CreateDevice, ID3D11Device,
-            ID3D11DeviceContext,
+use windows::{
+    Win32::{
+        Foundation::HMODULE,
+        Graphics::{
+            Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_DRIVER_TYPE_UNKNOWN},
+            Direct3D11::{
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION, D3D11CreateDevice,
+                ID3D11Device, ID3D11DeviceContext,
+            },
+            Dxgi::{IDXGIAdapter, IDXGIDevice},
         },
-        Dxgi::IDXGIAdapter,
     },
+    core::Interface,
 };
 
 pub struct DxInterop {
+    gpu_id: GpuLuid,
     pub device: ID3D11Device,
     pub cx: SyncWrapper<ID3D11DeviceContext>,
 }
@@ -37,14 +43,27 @@ impl DxInterop {
                 Some(&mut device),
                 None,
                 Some(&mut cx),
-            )?;
+            ).context("D3D11CreateDevice failed")?;
             let device = device.unwrap();
             let cx = cx.unwrap();
 
+            let luid = device
+                .cast::<IDXGIDevice>()?
+                .GetAdapter()?
+                .GetDesc()?
+                .AdapterLuid;
             Ok(Self {
+                gpu_id: GpuLuid {
+                    low: luid.LowPart,
+                    high: luid.HighPart,
+                },
                 device,
                 cx: SyncWrapper::new(cx),
             })
         }
+    }
+
+    pub const fn gpu_id(&self) -> GpuLuid {
+        self.gpu_id
     }
 }


### PR DESCRIPTION
* Resolve #49
  * Compatible gpu id is delivered through `WindowEvent::Added`
  * Incompatible surface set request will fail