### PR TITLE
fix: opengl hdc enumeration

### DIFF
--- a/crates/overlay/src/hook/opengl.rs
+++ b/crates/overlay/src/hook/opengl.rs
@@ -14,7 +14,7 @@ use windows::{
         Foundation::{HMODULE, HWND},
         Graphics::{
             Dxgi::{CreateDXGIFactory1, IDXGIFactory1},
-            Gdi::{GetWindowDC, HDC, WindowFromDC},
+            Gdi::{HDC, WindowFromDC},
             OpenGL::{
                 HGLRC, wglGetCurrentContext, wglGetCurrentDC, wglGetProcAddress, wglMakeCurrent,
             },


### PR DESCRIPTION
* Fix `D3DKMTOpenAdapterFromHdc` returning wrong adapter due to usage of Window HDC instead of OpenGL HDC(Client area HDC) on hybrid GPU system