### PR TITLE
fix: prevent cursor being moved when input blocked

### DIFF
--- a/crates/overlay/src/hook/proc/input.rs
+++ b/crates/overlay/src/hook/proc/input.rs
@@ -100,8 +100,7 @@ pub fn hook() -> anyhow::Result<()> {
         let get_clip_cursor = DetourHook::attach(GetClipCursor as _, hooked_get_clip_cursor as _)?;
 
         debug!("hooking GetCursorPos");
-        let get_cursor_pos =
-            DetourHook::attach(GetCursorPos as _, hooked_get_cursor_pos as _)?;
+        let get_cursor_pos = DetourHook::attach(GetCursorPos as _, hooked_get_cursor_pos as _)?;
 
         debug!("hooking GetPhysicalCursorPos");
         let get_physical_cursor_pos = DetourHook::attach(


### PR DESCRIPTION
* Prevent cursor being moved when input blocked.
* Prevent last `RAWINPUT` data is being used on `GetRawInputData`. On some games, `RAWINPUT` seems to be reused if not overwritten correctly regardless return status code.
* Close #137 