### PR TITLE
Improve block input for sdl games

### DIFF
--- a/crates/overlay/src/backend/window/proc.rs
+++ b/crates/overlay/src/backend/window/proc.rs
@@ -404,15 +404,14 @@ fn process_wnd_proc(
                         ));
                     }
 
-                    if comp.contains(ime::GCS_RESULTSTR) {
-                        if let Some(text) = get_ime_string(himc, ime::GCS_RESULTSTR) {
+                    if comp.contains(ime::GCS_RESULTSTR)
+                        && let Some(text) = get_ime_string(himc, ime::GCS_RESULTSTR) {
                             proc.ime = ImeState::Enabled;
                             OverlayEventSink::emit(keyboard_input(
                                 backend.id,
                                 KeyboardInput::Ime(Ime::Commit(text.to_utf8())),
                             ));
                         }
-                    }
 
                     if comp.0 & (ime::GCS_COMPSTR | ime::GCS_COMPATTR | ime::GCS_CURSORPOS).0 != 0 {
                         let caret = if !comp.contains(IME_COMPOSITION_STRING(ime::CS_NOMOVECARET))

--- a/crates/overlay/src/hook/dx/dxgi.rs
+++ b/crates/overlay/src/hook/dx/dxgi.rs
@@ -59,8 +59,8 @@ fn draw_overlay(swapchain: &IDXGISwapChain1) {
         ) {
             error!("Backends::with_or_init_backend failed. err: {:?}", _err);
         }
-    } else if let Ok(device) = unsafe { swapchain.GetDevice::<ID3D11Device1>() } {
-        if let Err(_err) = Backends::with_or_init_backend(
+    } else if let Ok(device) = unsafe { swapchain.GetDevice::<ID3D11Device1>() }
+        && let Err(_err) = Backends::with_or_init_backend(
             hwnd.0 as _,
             || unsafe { device.cast::<IDXGIDevice>().unwrap().GetAdapter().ok() },
             |backend| {
@@ -69,7 +69,6 @@ fn draw_overlay(swapchain: &IDXGISwapChain1) {
         ) {
             error!("Backends::with_or_init_backend failed. err: {:?}", _err);
         }
-    }
 }
 
 #[tracing::instrument]

--- a/crates/overlay/src/hook/opengl.rs
+++ b/crates/overlay/src/hook/opengl.rs
@@ -151,14 +151,13 @@ fn draw_overlay(hdc: HDC) {
             let size = surface.size();
             let position = render.position;
             let screen = render.window_size;
-            if render.surface.invalidate_update() {
-                if let Err(err) =
+            if render.surface.invalidate_update()
+                && let Err(err) =
                     renderer.update_texture(render.surface.get().map(|surface| surface.texture()))
                 {
                     error!("failed to update opengl texture. err: {err:?}");
                     return;
                 }
-            }
 
             let _res = renderer.draw(position, size, screen);
             trace!("opengl render: {:?}", _res);

--- a/crates/overlay/src/hook/proc.rs
+++ b/crates/overlay/src/hook/proc.rs
@@ -152,9 +152,7 @@ extern "system" fn hooked_get_message_a(
             // For SDL games: Emit events BEFORE filtering so overlay gets them
             // even if we filter the message to block SDL
             emit_input_event_from_message(&*lpmsg);
-            
-            // Filter messages for SDL games that poll events
-            // Only filter if blocking AND not listening (no overlay interaction needed)
+
             if should_filter_message(&*lpmsg) {
                 (*lpmsg).message = msg::WM_NULL;
             }

--- a/crates/overlay/src/hook/proc.rs
+++ b/crates/overlay/src/hook/proc.rs
@@ -139,7 +139,10 @@ unsafe fn process_read_message<const UNICODE: bool>(
             emit_input_event_from_message(msg);
             if should_filter_message(msg) {
                 unsafe {
+                    // Call TranslateMessage for char messages
                     _ = TranslateMessage(msg);
+
+                    // Call Default WndProc so non client area works.
                     if UNICODE {
                         CallWindowProcW(
                             Some(DefWindowProcA),
@@ -187,6 +190,7 @@ unsafe fn process_peek_message(
             on_message_read(msg);
 
             if should_filter {
+                // Call TranslateMessage for char messages.
                 unsafe {
                     _ = TranslateMessage(msg);
                 }

--- a/crates/overlay/src/hook/proc/input.rs
+++ b/crates/overlay/src/hook/proc/input.rs
@@ -215,6 +215,12 @@ extern "system" fn hooked_get_clip_cursor(lprect: *mut RECT) -> BOOL {
 #[tracing::instrument]
 extern "system" fn hooked_get_cursor_pos(lppoint: *mut POINT) -> BOOL {
     if foreground_hwnd_input_blocked() {
+        // Return a fixed position instead of the real cursor position to prevent games from tracking mouse movement
+        if !lppoint.is_null() {
+            unsafe {
+                lppoint.write(POINT { x: 0, y: 0 });
+            }
+        }
         return BOOL(1);
     }
 
@@ -224,6 +230,12 @@ extern "system" fn hooked_get_cursor_pos(lppoint: *mut POINT) -> BOOL {
 #[tracing::instrument]
 extern "system" fn hooked_get_physical_cursor_pos(lppoint: *mut POINT) -> BOOL {
     if foreground_hwnd_input_blocked() {
+        // Return a fixed position instead of the real cursor position to prevent games from tracking mouse movement
+        if !lppoint.is_null() {
+            unsafe {
+                lppoint.write(POINT { x: 0, y: 0 });
+            }
+        }
         return BOOL(1);
     }
 


### PR DESCRIPTION
- Add input event emission for SDL games using PeekMessage/GetMessage
- Filter input messages to block them from reaching the game
- Spoof cursor position to prevent games from tracking mouse movement

This PR fixes Don't Starve Together issue mentioned on https://github.com/storycraft/asdf-overlay/issues/136.
Feel free to give advice or modify as you wish!