### PR TITLE
Support composition swapchain (e.g. Godot 4 DX12)

### DIFF
--- a/crates/overlay/src/hook/dx/dxgi.rs
+++ b/crates/overlay/src/hook/dx/dxgi.rs
@@ -26,9 +26,7 @@ use windows::{
             },
         },
         System::Threading::GetCurrentProcessId,
-        UI::WindowsAndMessaging::{
-            EnumWindows, GetWindowThreadProcessId, IsWindowVisible,
-        },
+        UI::WindowsAndMessaging::{EnumWindows, GetWindowThreadProcessId, IsWindowVisible},
     },
     core::{BOOL, HRESULT, Interface},
 };
@@ -71,11 +69,7 @@ fn find_process_window() -> Option<HWND> {
     }
 
     let h = data.hwnd.load(std::sync::atomic::Ordering::Relaxed);
-    if h != 0 {
-        Some(HWND(h as _))
-    } else {
-        None
-    }
+    if h != 0 { Some(HWND(h as _)) } else { None }
 }
 
 #[tracing::instrument]

--- a/crates/overlay/src/hook/dx/dxgi.rs
+++ b/crates/overlay/src/hook/dx/dxgi.rs
@@ -41,35 +41,36 @@ use crate::{
 /// Used as a fallback when the swapchain has no associated HWND
 /// (e.g. created via `CreateSwapChainForComposition`).
 fn find_process_window() -> Option<HWND> {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     struct EnumData {
         pid: u32,
-        hwnd: AtomicUsize,
+        hwnd: usize,
     }
 
     unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
-        let data = unsafe { &*(lparam.0 as *const EnumData) };
+        let data = unsafe { &mut *(lparam.0 as *mut EnumData) };
         let mut wnd_pid = 0u32;
         unsafe { GetWindowThreadProcessId(hwnd, Some(&mut wnd_pid)) };
         if wnd_pid == data.pid && unsafe { IsWindowVisible(hwnd) }.as_bool() {
-            data.hwnd.store(hwnd.0 as usize, Ordering::Relaxed);
+            data.hwnd = hwnd.0 as usize;
             return BOOL(0); // stop enumeration
         }
         BOOL(1) // continue
     }
 
-    let data = EnumData {
+    let mut data = EnumData {
         pid: unsafe { GetCurrentProcessId() },
-        hwnd: AtomicUsize::new(0),
+        hwnd: 0,
     };
 
     unsafe {
-        let _ = EnumWindows(Some(enum_callback), LPARAM(&data as *const _ as isize));
+        let _ = EnumWindows(Some(enum_callback), LPARAM(&mut data as *mut _ as isize));
     }
 
-    let h = data.hwnd.load(std::sync::atomic::Ordering::Relaxed);
-    if h != 0 { Some(HWND(h as _)) } else { None }
+    if data.hwnd != 0 {
+        Some(HWND(data.hwnd as _))
+    } else {
+        None
+    }
 }
 
 #[tracing::instrument]

--- a/crates/overlay/src/hook/dx/dxgi.rs
+++ b/crates/overlay/src/hook/dx/dxgi.rs
@@ -8,7 +8,7 @@ use once_cell::sync::OnceCell;
 use tracing::{debug, error, trace};
 use windows::{
     Win32::{
-        Foundation::{HMODULE, HWND},
+        Foundation::{HMODULE, HWND, LPARAM},
         Graphics::{
             Direct3D10::{
                 D3D10_DRIVER_TYPE_HARDWARE, D3D10_SDK_VERSION, D3D10CreateDeviceAndSwapChain,
@@ -21,9 +21,13 @@ use windows::{
                 },
                 CreateDXGIFactory1, DXGI_PRESENT, DXGI_PRESENT_PARAMETERS, DXGI_PRESENT_TEST,
                 DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_EFFECT_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                IDXGIAdapter, IDXGIDevice, IDXGIFactory1, IDXGIFactory4, IDXGISwapChain1,
-                IDXGISwapChain3,
+                IDXGIAdapter, IDXGIDevice, IDXGIFactory1, IDXGIFactory4, IDXGISwapChain,
+                IDXGISwapChain1, IDXGISwapChain3,
             },
+        },
+        System::Threading::GetCurrentProcessId,
+        UI::WindowsAndMessaging::{
+            EnumWindows, GetWindowThreadProcessId, IsWindowVisible,
         },
     },
     core::{BOOL, HRESULT, Interface},
@@ -35,10 +39,67 @@ use crate::{
     hook::dx::{dx11, dx12},
 };
 
+/// Find the main visible window belonging to the current process.
+/// Used as a fallback when the swapchain has no associated HWND
+/// (e.g. created via `CreateSwapChainForComposition`).
+fn find_process_window() -> Option<HWND> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct EnumData {
+        pid: u32,
+        hwnd: AtomicUsize,
+    }
+
+    unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let data = unsafe { &*(lparam.0 as *const EnumData) };
+        let mut wnd_pid = 0u32;
+        unsafe { GetWindowThreadProcessId(hwnd, Some(&mut wnd_pid)) };
+        if wnd_pid == data.pid && unsafe { IsWindowVisible(hwnd) }.as_bool() {
+            data.hwnd.store(hwnd.0 as usize, Ordering::Relaxed);
+            return BOOL(0); // stop enumeration
+        }
+        BOOL(1) // continue
+    }
+
+    let data = EnumData {
+        pid: unsafe { GetCurrentProcessId() },
+        hwnd: AtomicUsize::new(0),
+    };
+
+    unsafe {
+        let _ = EnumWindows(Some(enum_callback), LPARAM(&data as *const _ as isize));
+    }
+
+    let h = data.hwnd.load(std::sync::atomic::Ordering::Relaxed);
+    if h != 0 {
+        Some(HWND(h as _))
+    } else {
+        None
+    }
+}
+
 #[tracing::instrument]
 fn draw_overlay(swapchain: &IDXGISwapChain1) {
-    let Ok(hwnd) = (unsafe { swapchain.GetHwnd() }) else {
-        return;
+    let hwnd = match unsafe { swapchain.GetHwnd() } {
+        Ok(hwnd) => hwnd,
+        Err(_) => {
+            // GetHwnd() fails for swapchains created via CreateSwapChainForComposition.
+            // Fall back to GetDesc().OutputWindow, then process window enumeration.
+            let from_desc = swapchain
+                .cast::<IDXGISwapChain>()
+                .ok()
+                .and_then(|sc| unsafe { sc.GetDesc() }.ok())
+                .filter(|desc| !desc.OutputWindow.is_invalid() && desc.OutputWindow.0 as usize != 0)
+                .map(|desc| desc.OutputWindow);
+
+            if let Some(hwnd) = from_desc {
+                hwnd
+            } else if let Some(hwnd) = find_process_window() {
+                hwnd
+            } else {
+                return;
+            }
+        }
     };
 
     if let Ok(device) = unsafe { swapchain.GetDevice::<ID3D12Device>() } {

--- a/crates/overlay/src/hook/proc/input.rs
+++ b/crates/overlay/src/hook/proc/input.rs
@@ -270,25 +270,42 @@ extern "system" fn hooked_get_raw_input_data(
     cbsizeheader: u32,
 ) -> u32 {
     if foreground_hwnd_input_blocked() {
-        if !pdata.is_null() {
-            match uicommand {
-                RID_HEADER => {
-                    unsafe {
-                        pdata
-                            .cast::<RAWINPUTHEADER>()
-                            .write(RAWINPUTHEADER::default());
-                    };
-                }
+        // Determine the expected data size based on the command, matching the
+        // real Win32 API behaviour so callers (e.g. Godot 4) that validate the
+        // returned size against the queried size do not crash.
+        let data_size: u32 = match uicommand {
+            RID_HEADER => core::mem::size_of::<RAWINPUTHEADER>() as u32,
+            RID_INPUT => core::mem::size_of::<RAWINPUT>() as u32,
+            _ => 0,
+        };
 
-                RID_INPUT => unsafe {
-                    pdata.cast::<RAWINPUT>().write(RAWINPUT::default());
-                },
-
-                _ => {}
+        if pdata.is_null() {
+            // Size query: write the required buffer size and return 0 (success).
+            if !pcbsize.is_null() {
+                unsafe { pcbsize.write(data_size) };
             }
+            return 0;
         }
 
-        return 0;
+        // Data query: write a zeroed struct and return the number of bytes
+        // written, exactly as the real API would on success.
+        if !pcbsize.is_null() {
+            unsafe { pcbsize.write(data_size) };
+        }
+
+        match uicommand {
+            RID_HEADER => unsafe {
+                pdata
+                    .cast::<RAWINPUTHEADER>()
+                    .write(RAWINPUTHEADER::default());
+            },
+            RID_INPUT => unsafe {
+                pdata.cast::<RAWINPUT>().write(RAWINPUT::default());
+            },
+            _ => {}
+        }
+
+        return data_size;
     }
 
     unsafe {

--- a/crates/overlay/src/hook/proc/input.rs
+++ b/crates/overlay/src/hook/proc/input.rs
@@ -279,28 +279,36 @@ extern "system" fn hooked_get_raw_input_data(
             _ => 0,
         };
 
-        if pdata.is_null() {
-            // Size query: write the required buffer size and return 0 (success).
-            if !pcbsize.is_null() {
-                unsafe { pcbsize.write(data_size) };
-            }
-            return 0;
-        }
-
-        // Data query: write a zeroed struct and return the number of bytes
-        // written, exactly as the real API would on success.
         if !pcbsize.is_null() {
             unsafe { pcbsize.write(data_size) };
         }
 
+        // Size query: return 0 (success) after writing the required buffer size.
+        if pdata.is_null() {
+            return 0;
+        }
+
+        // Data query: write a dummy HID struct and return the number of bytes
+        // written, exactly as the real API would on success.
+        // Use RIM_TYPEHID so games treat this as an unknown HID device and
+        // ignore the empty payload instead of interpreting zeroed fields as
+        // mouse/keyboard input.
+
+        let hid_header = RAWINPUTHEADER {
+            dwType: 2, // RIM_TYPEHID
+            dwSize: data_size,
+            ..Default::default()
+        };
+
         match uicommand {
             RID_HEADER => unsafe {
-                pdata
-                    .cast::<RAWINPUTHEADER>()
-                    .write(RAWINPUTHEADER::default());
+                pdata.cast::<RAWINPUTHEADER>().write(hid_header);
             },
             RID_INPUT => unsafe {
-                pdata.cast::<RAWINPUT>().write(RAWINPUT::default());
+                pdata.cast::<RAWINPUT>().write(RAWINPUT {
+                    header: hid_header,
+                    ..Default::default()
+                });
             },
             _ => {}
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,7 +95,6 @@ export type OverlayEventEmitter = EventEmitter<{
 export class Overlay {
   readonly event: OverlayEventEmitter = new EventEmitter();
   readonly [idSym]: unknown;
-  private destroyed = false;
 
   private constructor(id: unknown) {
     this[idSym] = id;
@@ -217,8 +216,6 @@ export class Overlay {
    * Destroy overlay
    */
   destroy() {
-    if (this.destroyed) return;
-    this.destroyed = true;
     addon.overlayDestroy(this[idSym]);
     this.event.emit('disconnected');
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export type OverlayEventEmitter = EventEmitter<{
 export class Overlay {
   readonly event: OverlayEventEmitter = new EventEmitter();
   readonly [idSym]: unknown;
+  private destroyed = false;
 
   private constructor(id: unknown) {
     this[idSym] = id;
@@ -216,6 +217,8 @@ export class Overlay {
    * Destroy overlay
    */
   destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
     addon.overlayDestroy(this[idSym]);
     this.event.emit('disconnected');
   }


### PR DESCRIPTION
Fixes Slay the Spire 2 issue #159 

### 오버레이가 표시되지 않는 문제 수정

`CreateSwapChainForComposition`으로 생성된 swapchain에는 HWND가 연결되어 있지 않아 `GetHwnd()` 호출이 실패. `GetDesc().OutputWindow` → `EnumWindows` 프로세스 윈도우 탐색 순서로 fallback하여 HWND를 확보하도록 수정.

### Input blocking 시 크래시 수정

`GetRawInputData` 훅이 input blocking 활성화 시 Win32 API 계약을 위반.
- `pdata = NULL` (사이즈 쿼리) 시 `*pcbsize`에 필요한 버퍼 크기를 쓰지 않음
- `pdata ≠ NULL` (데이터 fetch) 시 반환값이 항상 0 (실제 API는 쓴 바이트 수를 반환)

Godot 4는 반환된 사이즈를 검증하기 때문에 100% 크래시가 발생했고, LWJGL(마인크래프트)에서도 타이밍에 따라 간헐적 크래시를 유발.

`size_of::<RAWINPUT>()`/`size_of::<RAWINPUTHEADER>()`로 올바른 사이즈를 `*pcbsize`에 기록하고, 데이터 fetch 시 실제 쓴 바이트 수를 반환하도록 수정.