### PR TITLE
Add destroy guard to Overlay

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export type OverlayEventEmitter = EventEmitter<{
 export class Overlay {
   readonly event: OverlayEventEmitter = new EventEmitter();
   readonly [idSym]: unknown;
+  private destroyed = false;
 
   private constructor(id: unknown) {
     this[idSym] = id;
@@ -216,6 +217,8 @@ export class Overlay {
    * Destroy overlay
    */
   destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
     addon.overlayDestroy(this[idSym]);
     this.event.emit('disconnected');
   }


### PR DESCRIPTION
Overlay.destroy()에 destroyed 플래그를 추가하여 중복 호출 시 overlayDestroy와 disconnected 이벤트가 이중으로 실행되지 않도록 수정.