### PR TITLE
Fix input blocking click through bug on some games

### DIFF
--- a/crates/overlay/src/backend/window/proc.rs
+++ b/crates/overlay/src/backend/window/proc.rs
@@ -52,16 +52,6 @@ fn process_wnd_proc(
     lparam: LPARAM,
 ) -> Option<LRESULT> {
     match msg {
-        // Some games receive mouse/keyboard input through WM_INPUT,
-        // bypassing the standard WM_LBUTTONDOWN etc. message filtering.
-        // We must call DefWindowProc so Windows can clean up the HRAWINPUT handle.
-        msg::WM_INPUT => {
-            let proc = backend.proc.lock();
-            if proc.input_blocking() {
-                return Some(unsafe { DefWindowProcA(HWND(backend.id as _), msg, wparam, lparam) });
-            }
-        }
-
         msg::WM_WINDOWPOSCHANGED => {
             let new_size = get_client_size(HWND(backend.id as _)).unwrap();
             let mut render = backend.render.lock();

--- a/crates/overlay/src/backend/window/proc.rs
+++ b/crates/overlay/src/backend/window/proc.rs
@@ -52,6 +52,16 @@ fn process_wnd_proc(
     lparam: LPARAM,
 ) -> Option<LRESULT> {
     match msg {
+        // Some games receive mouse/keyboard input through WM_INPUT,
+        // bypassing the standard WM_LBUTTONDOWN etc. message filtering.
+        // We must call DefWindowProc so Windows can clean up the HRAWINPUT handle.
+        msg::WM_INPUT => {
+            let proc = backend.proc.lock();
+            if proc.input_blocking() {
+                return Some(unsafe { DefWindowProcA(HWND(backend.id as _), msg, wparam, lparam) });
+            }
+        }
+
         msg::WM_WINDOWPOSCHANGED => {
             let new_size = get_client_size(HWND(backend.id as _)).unwrap();
             let mut render = backend.render.lock();
@@ -289,13 +299,31 @@ fn process_wnd_proc(
             }
         }
 
+        // Block WM_POINTER* by forwarding to DefWindowProc, which converts them
+        // to legacy WM_LBUTTON*/WM_MOUSEMOVE/WM_MOUSEWHEEL messages.
+        // Those legacy messages then re-enter this WndProc where they are
+        // emitted to the overlay UI and blocked from the game.
+        msg::WM_POINTERUPDATE
+        | msg::WM_POINTERDOWN
+        | msg::WM_POINTERUP
+        | msg::WM_POINTERENTER
+        | msg::WM_POINTERLEAVE
+        | msg::WM_POINTERACTIVATE
+        | msg::WM_POINTERCAPTURECHANGED
+        | msg::WM_POINTERWHEEL
+        | msg::WM_POINTERHWHEEL => {
+            let proc = backend.proc.lock();
+            if proc.input_blocking() {
+                return Some(unsafe { DefWindowProcA(HWND(backend.id as _), msg, wparam, lparam) });
+            }
+        }
+
         // block other keyboard, mouse event
         msg::WM_CAPTURECHANGED
         | msg::WM_ACTIVATE
         | msg::WM_ACTIVATEAPP
         | msg::WM_SETFOCUS
         | msg::WM_KILLFOCUS
-        | msg::WM_POINTERUPDATE
         | msg::WM_DEADCHAR
         | msg::WM_HOTKEY
         | msg::WM_SYSDEADCHAR

--- a/crates/overlay/src/hook/proc.rs
+++ b/crates/overlay/src/hook/proc.rs
@@ -486,7 +486,8 @@ fn is_keyboard_message(message: u32) -> bool {
 /// Filter input messages when blocking is enabled
 #[inline]
 fn should_filter_message(msg: &MSG) -> bool {
-    if !is_cursor_message(msg.message) && !is_keyboard_message(msg.message) {
+    let dominated = is_cursor_message(msg.message) || is_keyboard_message(msg.message) || msg.message == msg::WM_INPUT;
+    if !dominated {
         return false;
     }
 

--- a/crates/overlay/src/hook/proc.rs
+++ b/crates/overlay/src/hook/proc.rs
@@ -486,10 +486,7 @@ fn is_keyboard_message(message: u32) -> bool {
 /// Filter input messages when blocking is enabled
 #[inline]
 fn should_filter_message(msg: &MSG) -> bool {
-    let dominated = is_cursor_message(msg.message)
-        || is_keyboard_message(msg.message)
-        || msg.message == msg::WM_INPUT;
-    if !dominated {
+    if !is_cursor_message(msg.message) && !is_keyboard_message(msg.message) {
         return false;
     }
 

--- a/crates/overlay/src/hook/proc.rs
+++ b/crates/overlay/src/hook/proc.rs
@@ -486,7 +486,9 @@ fn is_keyboard_message(message: u32) -> bool {
 /// Filter input messages when blocking is enabled
 #[inline]
 fn should_filter_message(msg: &MSG) -> bool {
-    let dominated = is_cursor_message(msg.message) || is_keyboard_message(msg.message) || msg.message == msg::WM_INPUT;
+    let dominated = is_cursor_message(msg.message)
+        || is_keyboard_message(msg.message)
+        || msg.message == msg::WM_INPUT;
     if !dominated {
         return false;
     }


### PR DESCRIPTION
Peak, Valheim, Super Battle Golf 게임에서 input blocking 시 게임에 마우스 클릭 이벤트가 전달되는 버그 수정 (Fixes #163)

### 주요 원인
미차단 입력 경로 존재
`WM_POINTER*` — Windows 8+ Pointer Input 메시지가 `WM_POINTERUPDATE`만 차단하고 `WM_POINTERDOWN`/`WM_POINTERUP` 등은 누락.

+) 현재는 오버레이 UI 쪽으로 event는 전달 하면서 게임 쪽은 blocking 하기 위해 WndProc 에서 레거시 메시지로 변환하여 처리. 추후 자식 창으로 WM_POINTER* 관련 입력 받는 경우까지 커버하기 위해서는 `hook/proc.rs`에서 필터링 후 오버레이 UI 쪽으로 이벤트 emit 하는 부분의 코드 변경 필요. `DefWindowProc`이 해주는 것처럼 레거시 메세지로 직접 변환하거나, `emit_cursor_event_from_message`에 WM_POINTER* 관련 분기 추가