### PR TITLE
feat: Request action result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
  "rmp-serde",
  "scopeguard",
  "serde",
+ "thiserror 2.0.20",
  "tokio",
  "windows 0.62.2",
 ]
@@ -357,6 +358,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "scopeguard",
  "serde",
+ "serde-error",
  "tokio",
  "winapi",
 ]
@@ -1356,7 +1358,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1799,9 +1801,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
+checksum = "75382bc7392ef10aad10935f92fc3db36d2d4dad0e5d96d8d65e04f89a07ec39"
 dependencies = [
  "bytemuck",
 ]
@@ -1844,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1859,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1869,15 +1871,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1886,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1905,32 +1907,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2475,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2489,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2502,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2516,16 +2518,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2536,15 +2539,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2843,7 +2846,7 @@ dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.1",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -2866,9 +2869,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -3187,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -3943,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4171,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -4364,6 +4367,15 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-error"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342110fb7a5d801060c885da03bf91bfa7c7ca936deafcc64bb6706375605d47"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4983,9 +4995,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6402,9 +6414,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -6704,9 +6716,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6715,9 +6727,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6726,13 +6738,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -29,6 +29,7 @@ goblin = { version = "0.10.0", default-features = false, features = [
     "pe32",
     "pe64",
 ] }
+thiserror = "2.0.20"
 
 [dependencies.windows]
 workspace = true

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -9,7 +9,7 @@ use asdf_overlay_common::{
     event::OverlayEvent,
     ipc::{ClientRequest, Frame, ServerToClientPacket},
     request::{
-        Request, Requestable,
+        self, Request, Requestable,
         surface::{SurfaceRequest, SurfaceRequestable},
         window::{WindowRequest, WindowRequestable},
     },
@@ -95,11 +95,11 @@ impl IpcClientConn {
 
     /// Send a request and wait for the response.
     /// Returns an error if the connection is closed or the request fails.
-    pub async fn request<T: Requestable>(&mut self, req: T) -> anyhow::Result<T::Response> {
+    pub async fn request<T: Requestable>(&mut self, req: T) -> Result<T::Response> {
         self.request_inner::<T::Response>(req.into()).await
     }
 
-    async fn request_inner<T: DeserializeOwned>(&mut self, req: Request) -> anyhow::Result<T> {
+    async fn request_inner<T: DeserializeOwned>(&mut self, req: Request) -> Result<T> {
         let data = self
             .send(req)
             .await
@@ -107,12 +107,14 @@ impl IpcClientConn {
             .await
             .context("failed to receive response")?;
 
-        rmp_serde::from_slice(&data).context("invalid response payload")
+        let res = rmp_serde::from_slice::<request::Result<T>>(&data)
+            .context("invalid response payload")?;
+        Ok(res.map_err(|err| request::Error::new(&err))?)
     }
 
     /// Send a request without waiting for the response.
     /// Returns a oneshot receiver that can be used to receive the response data.
-    async fn send(&mut self, req: Request) -> anyhow::Result<oneshot::Receiver<Vec<u8>>> {
+    async fn send(&mut self, req: Request) -> Result<oneshot::Receiver<Vec<u8>>> {
         let Some(map) = self.map.upgrade() else {
             bail!("connection closed");
         };
@@ -141,6 +143,23 @@ impl Drop for IpcClientConn {
     fn drop(&mut self) {
         self.read_task.abort();
     }
+}
+
+/// Client request result type.
+pub type Result<T> = core::result::Result<T, anyhow::Error>;
+
+/// Error type for IPC client connection.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("ipc io error")]
+    Io(
+        #[from]
+        #[source]
+        anyhow::Error,
+    ),
+
+    #[error("request failed")]
+    Request(#[from] request::Error),
 }
 
 /// Request interface for a specific window id.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 rmp-serde = "1.3.1"
 winapi = { version = "0.3", features = ["winerror"] }
 anyhow = "1.0.97"
+serde-error = "0.1.3"
 parking_lot = "0.12.3"
 async-stream = "0.3.6"
 rustc-hash = "2.1.1"

--- a/crates/common/src/request.rs
+++ b/crates/common/src/request.rs
@@ -5,6 +5,8 @@
 pub mod surface;
 pub mod window;
 
+use core::fmt;
+
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
@@ -26,6 +28,32 @@ pub enum Request {
 
     /// Request to a specific surface.
     Surface(SurfaceRequest),
+}
+
+/// Result type for IPC requests.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Serializable error type for IPC requests.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Error(serde_error::Error);
+
+impl Error {
+    pub fn new(error: &(impl ?Sized + core::error::Error)) -> Self {
+        Self(serde_error::Error::new(error))
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
 }
 
 /// Trait implemented for request types.

--- a/crates/dll/src/ipc.rs
+++ b/crates/dll/src/ipc.rs
@@ -1,5 +1,6 @@
 mod io;
 
+use anyhow::Context;
 use asdf_overlay::{
     event_sink::OverlayEventSink,
     surface::{SharedTextureHandle, Surfaces},
@@ -18,7 +19,7 @@ use asdf_overlay_window::{Backends, window::ListenInputFlags};
 use scopeguard::defer;
 use std::sync::Arc;
 use tokio::net::windows::named_pipe::NamedPipeServer;
-use tracing::{Level, debug, error, trace};
+use tracing::{Level, debug, trace};
 
 use crate::{cursors, event_sink::EventSink, ipc::io::IpcServerConn};
 
@@ -95,21 +96,25 @@ pub async fn run(
             }
 
             Request::BlockInput(BlockInput { block }) => {
-                if block {
-                    backends.block_input();
-                } else {
-                    backends.unblock_input();
-                }
+                conn.reply_with::<<BlockInput as Requestable>::Response>(req_id, || {
+                    if block {
+                        backends.block_input();
+                    } else {
+                        backends.unblock_input();
+                    }
 
-                conn.reply::<<BlockInput as Requestable>::Response>(req_id, ())?;
+                    Ok(())
+                })?;
             }
 
             Request::SetBlockingCursor(SetBlockingCursor { cursor }) => {
-                backends.set_blocking_cursor(
-                    cursor.and_then(|cursor| cursors::load(hinstance, cursor)),
-                );
+                conn.reply_with::<<SetBlockingCursor as Requestable>::Response>(req_id, || {
+                    backends.set_blocking_cursor(
+                        cursor.and_then(|cursor| cursors::load(hinstance, cursor)),
+                    );
 
-                conn.reply::<<SetBlockingCursor as Requestable>::Response>(req_id, ())?;
+                    Ok(())
+                })?;
             }
 
             Request::Surface(surface) => {
@@ -128,12 +133,15 @@ fn handle_window_request(
 ) -> anyhow::Result<()> {
     match req.kind {
         WindowRequestKind::ListenInput(cmd) => {
-            let mut flags = ListenInputFlags::empty();
-            flags.set(ListenInputFlags::CURSOR, cmd.cursor);
-            flags.set(ListenInputFlags::KEYBOARD, cmd.keyboard);
+            conn.reply_with::<<ListenInput as WindowRequestable>::Response>(req_id, || {
+                let mut flags = ListenInputFlags::empty();
+                flags.set(ListenInputFlags::CURSOR, cmd.cursor);
+                flags.set(ListenInputFlags::KEYBOARD, cmd.keyboard);
 
-            backends.window(req.id, |state| state.set_input_flags(flags));
-            conn.reply::<<ListenInput as WindowRequestable>::Response>(req_id, ())?;
+                backends.window(req.id, |state| state.set_input_flags(flags));
+
+                Ok(())
+            })?;
         }
     }
 
@@ -147,18 +155,27 @@ fn handle_surface_request(
 ) -> anyhow::Result<()> {
     match req.kind {
         SurfaceRequestKind::SetPosition(cmd) => {
-            _ = Surfaces::state(req.id, |state| state.reposition(cmd.x, cmd.y));
-            conn.reply::<<SetPosition as SurfaceRequestable>::Response>(req_id, ())?;
+            conn.reply_with::<<SetPosition as SurfaceRequestable>::Response>(req_id, || {
+                Surfaces::state(req.id, |state| state.reposition(cmd.x, cmd.y))
+                    .context("Surface not found")?;
+                Ok(())
+            })?;
         }
 
         SurfaceRequestKind::UpdateSharedHandle(shared) => {
-            Surfaces::state(req.id, |state| {
-                if let Err(err) = state.commit_overlay_texture(map_ipc_shtex_update(shared)) {
-                    error!("failed to open shared surface. err: {:?}", err);
-                }
-            });
+            conn.reply_with::<<UpdateSharedHandle as SurfaceRequestable>::Response>(
+                req_id,
+                || {
+                    Surfaces::state(req.id, |state| {
+                        state
+                            .commit_overlay_texture(map_ipc_shtex_update(shared))
+                            .context("Failed to commit overlay texture")
+                    })
+                    .context("Surface not found")??;
 
-            conn.reply::<<UpdateSharedHandle as SurfaceRequestable>::Response>(req_id, ())?;
+                    Ok(())
+                },
+            )?;
         }
     }
 

--- a/crates/dll/src/ipc/io.rs
+++ b/crates/dll/src/ipc/io.rs
@@ -2,10 +2,12 @@
 //! * Using [`IpcServerConn`] one can read requests from the client and reply to them.
 //! * Using [`IpcClientEventEmitter`] one can emit events to the client.
 
+use core::error::Error;
+
 use asdf_overlay_common::{
     event::OverlayEvent,
     ipc::{ClientRequest, Frame, ServerToClientPacket},
-    request::Request,
+    request::{self, Request},
 };
 use serde::Serialize;
 use tokio::{
@@ -73,10 +75,16 @@ impl IpcServerConn {
     }
 
     /// Reply to the client with the given request ID and data.
-    pub fn reply<T: Serialize>(&mut self, id: u32, response: T) -> anyhow::Result<()> {
+    pub fn reply_with<T: Serialize>(
+        &mut self,
+        id: u32,
+        f: impl FnOnce() -> anyhow::Result<T>,
+    ) -> anyhow::Result<()> {
         _ = self.chan.send(ServerToClientPacket::Response {
             id,
-            payload: rmp_serde::to_vec(&response)?,
+            payload: rmp_serde::to_vec(
+                &f().map_err(|err| request::Error::new(AsRef::<dyn Error>::as_ref(&err))),
+            )?,
         });
 
         Ok(())

--- a/crates/dll/src/lib.rs
+++ b/crates/dll/src/lib.rs
@@ -65,6 +65,7 @@ async fn main(module_handle: usize) -> anyhow::Result<()> {
                     warn!(error = ?err, "Client connection ended unexpectedly.");
                 }
             }
+
             Err(err) => {
                 error!(error = ?err, "Failed to connect to client.");
             }
@@ -76,7 +77,7 @@ async fn main(module_handle: usize) -> anyhow::Result<()> {
 
 async fn open_ipc_server<const FIRST: bool>(pid: u32, module_handle: u32) -> NamedPipeServer {
     loop {
-        match server::open::<true>(pid, module_handle as u32) {
+        match server::open::<true>(pid, module_handle) {
             Ok(server) => return server,
 
             Err(err) => {


### PR DESCRIPTION
* Add new `request::Result<T>`, `request::Error` type and mark all request failable.

Requests were silently failing with error previously. Now it doesn't.