### PR TITLE
fix: defer ExecuteCommandLists hook

### DIFF
--- a/crates/overlay/src/hook/dx.rs
+++ b/crates/overlay/src/hook/dx.rs
@@ -10,10 +10,6 @@ use windows::Win32::Foundation::HWND;
 
 #[tracing::instrument(level = Level::DEBUG)]
 pub fn hook(dummy_hwnd: HWND) {
-    if let Err(err) = dx12::hook() {
-        error!("failed to hook dx12. err: {err:?}");
-    }
-
     if let Err(err) = dxgi::hook(dummy_hwnd) {
         error!("failed to hook dxgi. err: {err:?}");
     }

--- a/crates/overlay/src/hook/dx/dx12.rs
+++ b/crates/overlay/src/hook/dx/dx12.rs
@@ -2,6 +2,7 @@ mod rtv;
 mod util;
 
 use asdf_overlay_event::{SurfaceInfo, SurfaceType};
+use parking_lot::Once;
 pub use util::original_execute_command_lists;
 
 use core::ffi::c_void;
@@ -10,13 +11,12 @@ use anyhow::Context;
 use asdf_overlay_hook::DetourHook;
 use dashmap::Entry;
 use once_cell::sync::{Lazy, OnceCell};
-use tracing::{Level, debug, info, trace};
+use tracing::{Level, debug, error, info, trace};
 use windows::{
     Win32::Graphics::{
-        Direct3D::D3D_FEATURE_LEVEL_11_0,
         Direct3D12::{
             D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_QUEUE_DESC,
-            D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12CreateDevice, ID3D12CommandQueue, ID3D12Device,
+            D3D12_COMMAND_QUEUE_FLAG_NONE, ID3D12CommandQueue, ID3D12Device,
         },
         Dxgi::{CreateDXGIFactory1, IDXGIAdapter, IDXGIFactory4, IDXGISwapChain1, IDXGISwapChain3},
     },
@@ -132,8 +132,14 @@ pub(super) fn setup_fn(
     device: &ID3D12Device,
     swapchain: &IDXGISwapChain1,
 ) -> anyhow::Result<SurfaceState> {
-    let desc = unsafe { swapchain.GetDesc1() }?;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        if let Err(err) = hook(device) {
+            error!("failed to hook dx12. err: {err:?}");
+        }
+    });
 
+    let desc = unsafe { swapchain.GetDesc1() }?;
     let interop = DxInterop::new(get_dxgi_adapter(device).as_ref())?;
     let window_id = unsafe { swapchain.GetHwnd() }
         .ok()
@@ -212,9 +218,9 @@ static HOOK: Hook = Hook {
     execute_command_lists: OnceCell::new(),
 };
 
-pub fn hook() -> anyhow::Result<()> {
+pub fn hook(device: &ID3D12Device) -> anyhow::Result<()> {
     let execute_command_lists =
-        get_execute_command_lists_addr().context("failed to load dx12 addrs")?;
+        get_execute_command_lists_addr(device).context("failed to load dx12 addrs")?;
     HOOK.execute_command_lists.get_or_try_init(|| unsafe {
         debug!("hooking ID3D12CommandQueue::ExecuteCommandLists");
         DetourHook::attach(execute_command_lists, hooked_execute_command_lists as _)
@@ -223,14 +229,10 @@ pub fn hook() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Get pointer to ID3D12CommandQueue::ExecuteCommandLists of D3D12_COMMAND_LIST_TYPE_DIRECT type by creating dummy device
+/// Get pointer to ID3D12CommandQueue::ExecuteCommandLists of D3D12_COMMAND_LIST_TYPE_DIRECT
 #[tracing::instrument(level = Level::TRACE)]
-fn get_execute_command_lists_addr() -> anyhow::Result<ExecuteCommandListsFn> {
+fn get_execute_command_lists_addr(device: &ID3D12Device) -> anyhow::Result<ExecuteCommandListsFn> {
     unsafe {
-        let mut device = None;
-        D3D12CreateDevice::<_, ID3D12Device>(None, D3D_FEATURE_LEVEL_11_0, &mut device)?;
-        let device = device.context("cannot create IDirect3DDevice12")?;
-
         let queue = device.CreateCommandQueue::<ID3D12CommandQueue>(&D3D12_COMMAND_QUEUE_DESC {
             Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
             Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,

--- a/crates/overlay/src/renderer/dx12.rs
+++ b/crates/overlay/src/renderer/dx12.rs
@@ -229,43 +229,7 @@ impl Dx12Renderer {
 
         if self
             .texture
-            .get_or_create(|handle| {
-                let mut texture = None;
-                unsafe {
-                    device
-                        .OpenSharedHandle::<ID3D12Resource>(
-                            HANDLE(handle.as_raw() as _),
-                            &mut texture,
-                        )
-                        .context("cannot open shared texture")?;
-                }
-                let texture = texture.unwrap();
-
-                let desc = unsafe { texture.GetDesc() };
-                if desc.Width == 0 || desc.Height == 0 {
-                    return Ok(None);
-                }
-
-                unsafe {
-                    device.CreateShaderResourceView(
-                        &texture,
-                        Some(&D3D12_SHADER_RESOURCE_VIEW_DESC {
-                            Shader4ComponentMapping: D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
-                            Format: desc.Format,
-                            ViewDimension: D3D12_SRV_DIMENSION_TEXTURE2D,
-                            Anonymous: D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
-                                Texture2D: D3D12_TEX2D_SRV {
-                                    MipLevels: 1,
-                                    ..Default::default()
-                                },
-                            },
-                        }),
-                        self.texture_descriptor.GetCPUDescriptorHandleForHeapStart(),
-                    );
-                }
-
-                Ok(Some(texture))
-            })?
+            .get_or_create(|handle| create_texture(device, &self.texture_descriptor, handle))?
             .is_none()
         {
             return Ok(());
@@ -343,6 +307,45 @@ impl Drop for Dx12Renderer {
 
 unsafe impl Send for Dx12Renderer {}
 unsafe impl Sync for Dx12Renderer {}
+
+fn create_texture(
+    device: &ID3D12Device,
+    texture_descriptor: &ID3D12DescriptorHeap,
+    handle: SharedTextureHandle,
+) -> anyhow::Result<Option<ID3D12Resource>> {
+    let mut texture = None;
+    unsafe {
+        device
+            .OpenSharedHandle::<ID3D12Resource>(HANDLE(handle.as_raw() as _), &mut texture)
+            .context("cannot open shared texture")?;
+    }
+    let texture = texture.unwrap();
+
+    let desc = unsafe { texture.GetDesc() };
+    if desc.Width == 0 || desc.Height == 0 {
+        return Ok(None);
+    }
+
+    unsafe {
+        device.CreateShaderResourceView(
+            &texture,
+            Some(&D3D12_SHADER_RESOURCE_VIEW_DESC {
+                Shader4ComponentMapping: D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+                Format: desc.Format,
+                ViewDimension: D3D12_SRV_DIMENSION_TEXTURE2D,
+                Anonymous: D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
+                    Texture2D: D3D12_TEX2D_SRV {
+                        MipLevels: 1,
+                        ..Default::default()
+                    },
+                },
+            }),
+            texture_descriptor.GetCPUDescriptorHandleForHeapStart(),
+        );
+    }
+
+    Ok(Some(texture))
+}
 
 unsafe fn transition(
     res: &ID3D12Resource,

--- a/crates/overlay/src/util.rs
+++ b/crates/overlay/src/util.rs
@@ -60,7 +60,7 @@ pub fn with_dummy_hwnd<R>(f: impl FnOnce(HWND) -> R) -> anyhow::Result<R> {
 }
 
 /// If [`IDXGIKeyedMutex`],
-/// * Exists, acquire the mutext with `0` value key, run closure and release.
+/// * Exists, acquire the mutex with `0` value key, run closure and release.
 /// * Not exists, just run closure.
 #[inline]
 pub fn with_keyed_mutex<R>(


### PR DESCRIPTION
* Close #203 
* Use first presenting `ID3D12Device` instead of dummy device.
* D3D12 independent devices might be used to create non-global sideloaded agility sdk device. link: https://microsoft.github.io/DirectX-Specs/d3d/IndependentDevices.html