### PR TITLE
fix: crashing on old gpu driver without `EXT_external_objects`

### DIFF
--- a/crates/overlay/src/hook/opengl.rs
+++ b/crates/overlay/src/hook/opengl.rs
@@ -348,6 +348,10 @@ fn setup_gl() -> anyhow::Result<()> {
 }
 
 fn get_dxgi_adapter() -> Option<IDXGIAdapter> {
+    if !gl::GetUnsignedBytevEXT::is_loaded() {
+        return None;
+    }
+
     let mut luid = LUID::default();
     unsafe {
         _ = gl::GetError();


### PR DESCRIPTION
* Check `GetUnsignedBytevEXT` is actually loaded before using it. Old drivers without `EXT_external_objects` will crash without check.